### PR TITLE
Subscribe to a podcast via RSS URL

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,36 @@
+import { useEffect, useState } from 'react'
+import { View, ActivityIndicator, StyleSheet } from 'react-native'
 import { StatusBar } from 'expo-status-bar'
-import { StyleSheet, Text, View } from 'react-native'
+import { openDatabase, type Database } from './src/db/database'
+import { createSubscriptionService } from './src/services/subscriptionService'
+import { LibraryScreen } from './src/screens/LibraryScreen'
 
 export default function App() {
+  const [db, setDb] = useState<Database | null>(null)
+
+  useEffect(() => {
+    openDatabase().then(setDb)
+  }, [])
+
+  if (!db) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" />
+        <StatusBar style="auto" />
+      </View>
+    )
+  }
+
+  const service = createSubscriptionService(db.subscriptions, db.episodes)
+
   return (
-    <View style={styles.container}>
-      <Text>hlyst</Text>
+    <>
+      <LibraryScreen subscriptionService={service} subscriptionDao={db.subscriptions} />
       <StatusBar style="auto" />
-    </View>
+    </>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
+  loading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 })

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,10 +1,10 @@
+import App from '../App'
+
 jest.mock('../src/screens/LibraryScreen', () => ({ LibraryScreen: () => null }))
 jest.mock('../src/db/database', () => ({ openDatabase: jest.fn() }))
 jest.mock('../src/services/subscriptionService', () => ({
   createSubscriptionService: jest.fn(),
 }))
-
-import App from '../App'
 
 it('App exports a React component', () => {
   expect(typeof App).toBe('function')

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,3 +1,9 @@
+jest.mock('../src/screens/LibraryScreen', () => ({ LibraryScreen: () => null }))
+jest.mock('../src/db/database', () => ({ openDatabase: jest.fn() }))
+jest.mock('../src/services/subscriptionService', () => ({
+  createSubscriptionService: jest.fn(),
+}))
+
 import App from '../App'
 
 it('App exports a React component', () => {

--- a/__tests__/rss/parser.test.ts
+++ b/__tests__/rss/parser.test.ts
@@ -1,0 +1,83 @@
+import { parseFeed } from '../../src/rss/parser'
+
+const VALID_FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Test Podcast</title>
+    <description>A test podcast</description>
+    <itunes:image href="https://example.com/image.jpg" />
+    <item>
+      <title>Episode 1</title>
+      <guid>ep1-guid</guid>
+      <description>First episode</description>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <enclosure url="https://example.com/ep1.mp3" type="audio/mpeg" length="12345" />
+      <itunes:duration>3600</itunes:duration>
+    </item>
+    <item>
+      <title>Episode 2</title>
+      <guid>ep2-guid</guid>
+      <pubDate>Tue, 02 Jan 2024 00:00:00 +0000</pubDate>
+      <enclosure url="https://example.com/ep2.mp3" type="audio/mpeg" length="67890" />
+    </item>
+  </channel>
+</rss>`
+
+const FEED_HH_MM_SS_DURATION = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Duration Podcast</title>
+    <item>
+      <title>Episode HH:MM:SS</title>
+      <guid>ep-hms</guid>
+      <enclosure url="https://example.com/ep.mp3" type="audio/mpeg" length="0" />
+      <itunes:duration>1:02:03</itunes:duration>
+    </item>
+  </channel>
+</rss>`
+
+describe('parseFeed', () => {
+  it('parses channel metadata', () => {
+    const result = parseFeed('https://example.com/feed.xml', VALID_FEED)
+    expect(result.title).toBe('Test Podcast')
+    expect(result.description).toBe('A test podcast')
+    expect(result.imageUrl).toBe('https://example.com/image.jpg')
+    expect(result.feedUrl).toBe('https://example.com/feed.xml')
+  })
+
+  it('parses episodes', () => {
+    const result = parseFeed('https://example.com/feed.xml', VALID_FEED)
+    expect(result.episodes).toHaveLength(2)
+  })
+
+  it('parses episode fields', () => {
+    const result = parseFeed('https://example.com/feed.xml', VALID_FEED)
+    const ep = result.episodes[0]
+    expect(ep.title).toBe('Episode 1')
+    expect(ep.guid).toBe('ep1-guid')
+    expect(ep.description).toBe('First episode')
+    expect(ep.mediaUrl).toBe('https://example.com/ep1.mp3')
+    expect(ep.fileSize).toBe(12345)
+    expect(ep.duration).toBe(3600)
+    expect(ep.publishedAt).toBe(new Date('Mon, 01 Jan 2024 00:00:00 +0000').getTime())
+  })
+
+  it('defaults missing duration to 0', () => {
+    const result = parseFeed('https://example.com/feed.xml', VALID_FEED)
+    const ep = result.episodes[1]
+    expect(ep.duration).toBe(0)
+  })
+
+  it('parses HH:MM:SS duration format', () => {
+    const result = parseFeed('https://example.com/feed.xml', FEED_HH_MM_SS_DURATION)
+    expect(result.episodes[0].duration).toBe(3723)
+  })
+
+  it('throws on malformed XML', () => {
+    expect(() => parseFeed('https://example.com/feed.xml', '<not valid xml <<')).toThrow()
+  })
+
+  it('throws when channel element is missing', () => {
+    expect(() => parseFeed('https://example.com/feed.xml', '<rss><notchannel/></rss>')).toThrow()
+  })
+})

--- a/__tests__/rss/parser.test.ts
+++ b/__tests__/rss/parser.test.ts
@@ -80,4 +80,20 @@ describe('parseFeed', () => {
   it('throws when channel element is missing', () => {
     expect(() => parseFeed('https://example.com/feed.xml', '<rss><notchannel/></rss>')).toThrow()
   })
+
+  it('handles CDATA-wrapped guid with attributes', () => {
+    const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Ep</title>
+      <guid isPermaLink="false"><![CDATA[cdata-guid-123]]></guid>
+      <enclosure url="https://example.com/ep.mp3" type="audio/mpeg" length="0" />
+    </item>
+  </channel>
+</rss>`
+    const result = parseFeed('https://example.com/feed.xml', feed)
+    expect(result.episodes[0].guid).toBe('cdata-guid-123')
+  })
 })

--- a/__tests__/services/subscriptionService.test.ts
+++ b/__tests__/services/subscriptionService.test.ts
@@ -88,7 +88,10 @@ describe('subscriptionService.subscribe', () => {
   it('fetches the feed URL', async () => {
     const service = createSubscriptionService(makeSubDao(), makeEpDao())
     await service.subscribe('https://example.com/feed.xml')
-    expect(global.fetch).toHaveBeenCalledWith('https://example.com/feed.xml')
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/feed.xml',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    )
   })
 
   it('inserts the subscription', async () => {

--- a/__tests__/services/subscriptionService.test.ts
+++ b/__tests__/services/subscriptionService.test.ts
@@ -1,0 +1,166 @@
+import { createSubscriptionService } from '../../src/services/subscriptionService'
+import type { SubscriptionDao } from '../../src/db/dao/subscriptionDao'
+import type { EpisodeDao } from '../../src/db/dao/episodeDao'
+import type { Subscription, Episode } from '../../src/db/types'
+
+const FEED_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Test Pod</title>
+    <description>desc</description>
+    <itunes:image href="https://example.com/img.jpg" />
+    <item>
+      <title>Ep 1</title>
+      <guid>g1</guid>
+      <enclosure url="https://example.com/ep1.mp3" type="audio/mpeg" length="1000" />
+      <itunes:duration>300</itunes:duration>
+    </item>
+  </channel>
+</rss>`
+
+function makeSub(overrides: Partial<Subscription> = {}): Subscription {
+  return {
+    id: 'sub-1',
+    feedUrl: 'https://example.com/feed.xml',
+    title: 'Test Pod',
+    imageUrl: 'https://example.com/img.jpg',
+    description: 'desc',
+    lastFetchedAt: null,
+    createdAt: 1000,
+    ...overrides,
+  }
+}
+
+function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+  return {
+    id: 'ep-1',
+    subscriptionId: 'sub-1',
+    guid: 'g1',
+    title: 'Ep 1',
+    description: null,
+    duration: 300,
+    publishedAt: null,
+    mediaUrl: 'https://example.com/ep1.mp3',
+    fileSize: 1000,
+    downloadStatus: 'none',
+    localPath: null,
+    playedAt: null,
+    isArchived: false,
+    createdAt: 1000,
+    ...overrides,
+  }
+}
+
+function makeSubDao(overrides: Partial<SubscriptionDao> = {}): SubscriptionDao {
+  return {
+    insert: jest.fn().mockResolvedValue(makeSub()),
+    findById: jest.fn().mockResolvedValue(null),
+    findByFeedUrl: jest.fn().mockResolvedValue(null),
+    findAll: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function makeEpDao(overrides: Partial<EpisodeDao> = {}): EpisodeDao {
+  return {
+    insert: jest.fn().mockResolvedValue(makeEpisode()),
+    findById: jest.fn().mockResolvedValue(null),
+    findBySubscriptionId: jest.fn().mockResolvedValue([]),
+    findByGuid: jest.fn().mockResolvedValue(null),
+    markPlayed: jest.fn().mockResolvedValue(undefined),
+    updateDownloadStatus: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+global.fetch = jest.fn()
+
+describe('subscriptionService.subscribe', () => {
+  beforeEach(() => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(FEED_XML),
+    })
+  })
+
+  it('fetches the feed URL', async () => {
+    const service = createSubscriptionService(makeSubDao(), makeEpDao())
+    await service.subscribe('https://example.com/feed.xml')
+    expect(global.fetch).toHaveBeenCalledWith('https://example.com/feed.xml')
+  })
+
+  it('inserts the subscription', async () => {
+    const subDao = makeSubDao()
+    const service = createSubscriptionService(subDao, makeEpDao())
+    await service.subscribe('https://example.com/feed.xml')
+    expect(subDao.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedUrl: 'https://example.com/feed.xml',
+        title: 'Test Pod',
+        imageUrl: 'https://example.com/img.jpg',
+        description: 'desc',
+      }),
+    )
+  })
+
+  it('inserts episodes', async () => {
+    const epDao = makeEpDao()
+    const service = createSubscriptionService(makeSubDao(), epDao)
+    await service.subscribe('https://example.com/feed.xml')
+    expect(epDao.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guid: 'g1',
+        title: 'Ep 1',
+        duration: 300,
+        mediaUrl: 'https://example.com/ep1.mp3',
+      }),
+    )
+  })
+
+  it('skips episodes already in the db (by guid)', async () => {
+    const epDao = makeEpDao({
+      findByGuid: jest.fn().mockResolvedValue(makeEpisode()),
+    })
+    const service = createSubscriptionService(makeSubDao(), epDao)
+    await service.subscribe('https://example.com/feed.xml')
+    expect(epDao.insert).not.toHaveBeenCalled()
+  })
+
+  it('throws when the feed URL is already subscribed', async () => {
+    const subDao = makeSubDao({
+      findByFeedUrl: jest.fn().mockResolvedValue(makeSub()),
+    })
+    const service = createSubscriptionService(subDao, makeEpDao())
+    await expect(service.subscribe('https://example.com/feed.xml')).rejects.toThrow(
+      /already subscribed/i,
+    )
+  })
+
+  it('throws a descriptive error when fetch fails', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 })
+    const service = createSubscriptionService(makeSubDao(), makeEpDao())
+    await expect(service.subscribe('https://example.com/feed.xml')).rejects.toThrow(/404/)
+  })
+
+  it('throws on malformed XML without corrupting the db', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('<bad xml <<'),
+    })
+    const subDao = makeSubDao()
+    const service = createSubscriptionService(subDao, makeEpDao())
+    await expect(service.subscribe('https://example.com/feed.xml')).rejects.toThrow()
+    expect(subDao.insert).not.toHaveBeenCalled()
+  })
+})
+
+describe('subscriptionService.unsubscribe', () => {
+  it('deletes the subscription', async () => {
+    const subDao = makeSubDao()
+    const service = createSubscriptionService(subDao, makeEpDao())
+    await service.unsubscribe('sub-1')
+    expect(subDao.delete).toHaveBeenCalledWith('sub-1')
+  })
+})

--- a/docs/implement/progress.md
+++ b/docs/implement/progress.md
@@ -1,38 +1,33 @@
-# Issue #2 — Define local data model and storage layer
+# Issue #3 — Subscribe to a podcast via RSS URL
 
 ## Header
 
-- **Branch:** feat/data-model-storage
+- **Branch:** feat/subscribe-rss-url
 - **Base branch:** main
 - **PR strategy:** one
 - **Skill-retro:** yes
-- **Timestamp:** 2026-05-08
+- **Timestamp:** 2026-05-11
 
 ## Plan Summary
 
-Install expo-sqlite and AsyncStorage. Define TypeScript types for all entities. Build a forward-only migration runner. Implement typed DAO factories (dependency injection) for 6 entities. Wrap AsyncStorage with a typed key-value store.
+Install fast-xml-parser. Build RSS 2.0 + iTunes namespace parser (fetch → parse → typed structs). Build a subscriptionService that orchestrates fetch/parse/persist/delete via existing DAOs. Build LibraryScreen UI (add URL input, subscription list, delete). Wire into App.tsx.
 
 ## Stories
 
-- [ ] Foundation: types + migration runner + db init
-- [ ] SubscriptionDao
-- [ ] EpisodeDao
-- [ ] QueueDao
-- [ ] RuleDao
-- [ ] DownloadDao
-- [ ] PlaybackStateDao
-- [ ] KeyValueStore
+- [ ] TDD cycle 1: RSS parser (src/rss/parser.ts)
+- [ ] TDD cycle 2: subscriptionService (src/services/subscriptionService.ts)
+- [ ] Cycle 3: LibraryScreen + App wiring (verify-mode)
 
 ## PR Body Draft
 
 ## Summary
-Define the local data model and storage layer for hlyst using expo-sqlite with typed DAOs and AsyncStorage for hot-path key-value writes.
+Implements RSS subscription via URL paste. Users can add a podcast by URL, see it in a library list, and remove it — all backed by the SQLite DAOs from issue #2.
 
 ## Stories completed
-- [ ] Foundation: types, schema migrations, migration runner, DB init (closes #2)
+- [ ] RSS parser + subscription service + library UI (closes #3)
 
 ## Test plan
-- All DAOs tested with mock db via dependency injection
-- Migration runner tested with mock db
-- AsyncStorage wrapper tested with jest mock
+- RSS parser unit tests (valid feed, malformed XML, missing duration)
+- Subscription service unit tests (mock DAOs)
 - tsc --noEmit passes
+- npm test passes

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,10 @@
+// crypto.randomUUID is available in React Native 0.73+ but not in the Jest/jsdom environment
+if (typeof crypto === 'undefined' || !crypto.randomUUID) {
+  let counter = 0
+  Object.defineProperty(globalThis, 'crypto', {
+    value: {
+      randomUUID: () => `test-uuid-${++counter}`,
+    },
+    writable: true,
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~54.0.33",
+        "expo-crypto": "~15.0.9",
         "expo-dev-client": "~6.0.21",
         "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
@@ -7216,6 +7217,18 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "15.0.9",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.9.tgz",
+      "integrity": "sha512-SNWKa2fXx7v9gkp1h/7nqXY5XN7qgNDn3yRc2aO0gWGbeMbvob/haMxxsPFe9f51aqH5NjNCqHf2kvLhvAd8KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-dev-client": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "expo-dev-client": "~6.0.21",
         "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
+        "fast-xml-parser": "^5.7.3",
         "react": "19.1.0",
         "react-native": "0.81.5"
       },
@@ -3167,6 +3168,18 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nolyfill/is-core-module": {
       "version": "1.0.39",
@@ -7624,6 +7637,43 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -12364,6 +12414,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -14119,6 +14184,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/structured-headers": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-0.4.1.tgz",
@@ -15142,6 +15219,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -4,17 +4,19 @@
   "main": "index.ts",
   "scripts": {
     "start": "expo start",
-    "ios": "expo start --ios",
+    "ios": "expo run:ios",
     "test": "jest --watchAll=false",
     "test:watch": "jest",
     "lint": "eslint .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "android": "expo run:android"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~54.0.33",
+    "expo-crypto": "~15.0.9",
     "expo-dev-client": "~6.0.21",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo-dev-client": "~6.0.21",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",
+    "fast-xml-parser": "^5.7.3",
     "react": "19.1.0",
     "react-native": "0.81.5"
   },
@@ -39,6 +40,9 @@
   },
   "jest": {
     "preset": "jest-expo",
+    "setupFiles": [
+      "./jest-setup.ts"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)"
     ]

--- a/src/rss/parser.ts
+++ b/src/rss/parser.ts
@@ -1,0 +1,70 @@
+import { XMLParser } from 'fast-xml-parser'
+
+export interface ParsedEpisode {
+  guid: string
+  title: string
+  description: string | null
+  mediaUrl: string
+  fileSize: number | null
+  duration: number
+  publishedAt: number | null
+}
+
+export interface ParsedFeed {
+  feedUrl: string
+  title: string
+  description: string | null
+  imageUrl: string | null
+  episodes: ParsedEpisode[]
+}
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  allowBooleanAttributes: true,
+})
+
+function parseDuration(raw: unknown): number {
+  if (raw === undefined || raw === null || raw === '') return 0
+  const str = String(raw)
+  if (str.includes(':')) {
+    const parts = str.split(':').map(Number)
+    if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
+    if (parts.length === 2) return parts[0] * 60 + parts[1]
+  }
+  const n = Number(str)
+  return isNaN(n) ? 0 : n
+}
+
+function parseItems(raw: unknown): ParsedEpisode[] {
+  if (!raw) return []
+  const items = Array.isArray(raw) ? raw : [raw]
+  return items
+    .filter((item) => item?.enclosure?.['@_url'])
+    .map((item) => ({
+      guid: String(item.guid ?? item.title ?? ''),
+      title: String(item.title ?? ''),
+      description: item.description ? String(item.description) : null,
+      mediaUrl: String(item.enclosure['@_url']),
+      fileSize: item.enclosure['@_length'] ? Number(item.enclosure['@_length']) : null,
+      duration: parseDuration(item['itunes:duration']),
+      publishedAt: item.pubDate ? new Date(String(item.pubDate)).getTime() : null,
+    }))
+}
+
+export function parseFeed(feedUrl: string, xml: string): ParsedFeed {
+  const result = parser.parse(xml)
+  const channel = result?.rss?.channel
+  if (!channel) throw new Error('Invalid RSS feed: missing <channel>')
+
+  const imageUrl =
+    channel['itunes:image']?.['@_href'] ?? channel.image?.url ?? null
+
+  return {
+    feedUrl,
+    title: String(channel.title ?? ''),
+    description: channel.description ? String(channel.description) : null,
+    imageUrl: imageUrl ? String(imageUrl) : null,
+    episodes: parseItems(channel.item),
+  }
+}

--- a/src/rss/parser.ts
+++ b/src/rss/parser.ts
@@ -36,13 +36,20 @@ function parseDuration(raw: unknown): number {
   return isNaN(n) ? 0 : n
 }
 
+function extractText(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'object' && '#text' in (value as object))
+    return String((value as Record<string, unknown>)['#text'])
+  return String(value)
+}
+
 function parseItems(raw: unknown): ParsedEpisode[] {
   if (!raw) return []
   const items = Array.isArray(raw) ? raw : [raw]
   return items
     .filter((item) => item?.enclosure?.['@_url'])
     .map((item) => ({
-      guid: String(item.guid ?? item.title ?? ''),
+      guid: extractText(item.guid) || extractText(item.title),
       title: String(item.title ?? ''),
       description: item.description ? String(item.description) : null,
       mediaUrl: String(item.enclosure['@_url']),

--- a/src/rss/parser.ts
+++ b/src/rss/parser.ts
@@ -22,6 +22,9 @@ const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
   allowBooleanAttributes: true,
+  // Treat HTML-bearing nodes as raw text so we never walk their nested tags
+  stopNodes: ['*.content:encoded', '*.description', '*.itunes:summary'],
+  maxNestedTags: 1000,
 })
 
 function parseDuration(raw: unknown): number {

--- a/src/rss/parser.ts
+++ b/src/rss/parser.ts
@@ -22,8 +22,6 @@ const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
   allowBooleanAttributes: true,
-  // Treat HTML-bearing nodes as raw text so we never walk their nested tags
-  stopNodes: ['*.content:encoded', '*.description', '*.itunes:summary'],
   maxNestedTags: 1000,
 })
 

--- a/src/rss/parser.ts
+++ b/src/rss/parser.ts
@@ -57,8 +57,7 @@ export function parseFeed(feedUrl: string, xml: string): ParsedFeed {
   const channel = result?.rss?.channel
   if (!channel) throw new Error('Invalid RSS feed: missing <channel>')
 
-  const imageUrl =
-    channel['itunes:image']?.['@_href'] ?? channel.image?.url ?? null
+  const imageUrl = channel['itunes:image']?.['@_href'] ?? channel.image?.url ?? null
 
   return {
     feedUrl,

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -78,7 +78,11 @@ export function LibraryScreen({ subscriptionService, subscriptionDao }: Props) {
           editable={!loading}
         />
         <TouchableOpacity style={styles.addButton} onPress={handleAdd} disabled={loading}>
-          {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.addButtonText}>Add</Text>}
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.addButtonText}>Add</Text>
+          )}
         </TouchableOpacity>
       </View>
 
@@ -91,16 +95,16 @@ export function LibraryScreen({ subscriptionService, subscriptionDao }: Props) {
           <View style={styles.row}>
             <View style={styles.rowText}>
               <Text style={styles.title}>{item.title}</Text>
-              <Text style={styles.feedUrl} numberOfLines={1}>{item.feedUrl}</Text>
+              <Text style={styles.feedUrl} numberOfLines={1}>
+                {item.feedUrl}
+              </Text>
             </View>
             <TouchableOpacity onPress={() => handleDelete(item)}>
               <Text style={styles.remove}>Remove</Text>
             </TouchableOpacity>
           </View>
         )}
-        ListEmptyComponent={
-          <Text style={styles.empty}>No podcasts yet. Add one above.</Text>
-        }
+        ListEmptyComponent={<Text style={styles.empty}>No podcasts yet. Add one above.</Text>}
       />
     </View>
   )

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  StyleSheet,
+  Alert,
+} from 'react-native'
+import type { Subscription } from '../db/types'
+import type { SubscriptionService } from '../services/subscriptionService'
+import type { SubscriptionDao } from '../db/dao/subscriptionDao'
+
+interface Props {
+  subscriptionService: SubscriptionService
+  subscriptionDao: SubscriptionDao
+}
+
+export function LibraryScreen({ subscriptionService, subscriptionDao }: Props) {
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>([])
+  const [url, setUrl] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadSubscriptions = useCallback(async () => {
+    const all = await subscriptionDao.findAll()
+    setSubscriptions(all)
+  }, [subscriptionDao])
+
+  useEffect(() => {
+    loadSubscriptions()
+  }, [loadSubscriptions])
+
+  async function handleAdd() {
+    if (!url.trim()) return
+    setLoading(true)
+    setError(null)
+    try {
+      await subscriptionService.subscribe(url.trim())
+      setUrl('')
+      await loadSubscriptions()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add podcast')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleDelete(sub: Subscription) {
+    Alert.alert('Remove podcast', `Remove "${sub.title}"?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Remove',
+        style: 'destructive',
+        onPress: async () => {
+          await subscriptionService.unsubscribe(sub.id)
+          await loadSubscriptions()
+        },
+      },
+    ])
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Library</Text>
+
+      <View style={styles.addRow}>
+        <TextInput
+          style={styles.input}
+          value={url}
+          onChangeText={setUrl}
+          placeholder="RSS feed URL"
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          editable={!loading}
+        />
+        <TouchableOpacity style={styles.addButton} onPress={handleAdd} disabled={loading}>
+          {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.addButtonText}>Add</Text>}
+        </TouchableOpacity>
+      </View>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <FlatList
+        data={subscriptions}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <View style={styles.rowText}>
+              <Text style={styles.title}>{item.title}</Text>
+              <Text style={styles.feedUrl} numberOfLines={1}>{item.feedUrl}</Text>
+            </View>
+            <TouchableOpacity onPress={() => handleDelete(item)}>
+              <Text style={styles.remove}>Remove</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+        ListEmptyComponent={
+          <Text style={styles.empty}>No podcasts yet. Add one above.</Text>
+        }
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingTop: 60, paddingHorizontal: 16, backgroundColor: '#fff' },
+  heading: { fontSize: 28, fontWeight: '700', marginBottom: 20 },
+  addRow: { flexDirection: 'row', gap: 8, marginBottom: 8 },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+  },
+  addButton: {
+    backgroundColor: '#007AFF',
+    borderRadius: 8,
+    paddingHorizontal: 18,
+    justifyContent: 'center',
+  },
+  addButtonText: { color: '#fff', fontWeight: '600', fontSize: 15 },
+  error: { color: '#d00', marginBottom: 8, fontSize: 13 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#e0e0e0',
+  },
+  rowText: { flex: 1 },
+  title: { fontSize: 16, fontWeight: '600' },
+  feedUrl: { fontSize: 12, color: '#888', marginTop: 2 },
+  remove: { color: '#d00', fontSize: 14, paddingLeft: 12 },
+  empty: { textAlign: 'center', color: '#888', marginTop: 48 },
+})

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,0 +1,61 @@
+import { parseFeed } from '../rss/parser'
+import type { SubscriptionDao } from '../db/dao/subscriptionDao'
+import type { EpisodeDao } from '../db/dao/episodeDao'
+import type { Subscription } from '../db/types'
+
+export interface SubscriptionService {
+  subscribe(feedUrl: string): Promise<Subscription>
+  unsubscribe(subscriptionId: string): Promise<void>
+}
+
+export function createSubscriptionService(
+  subscriptionDao: SubscriptionDao,
+  episodeDao: EpisodeDao,
+): SubscriptionService {
+  return {
+    async subscribe(feedUrl) {
+      const existing = await subscriptionDao.findByFeedUrl(feedUrl)
+      if (existing) throw new Error('Already subscribed to this feed')
+
+      const response = await fetch(feedUrl)
+      if (!response.ok) throw new Error(`Failed to fetch feed: HTTP ${response.status}`)
+
+      const xml = await response.text()
+      const feed = parseFeed(feedUrl, xml)
+
+      const now = Date.now()
+      const subscription = await subscriptionDao.insert({
+        id: crypto.randomUUID(),
+        feedUrl: feed.feedUrl,
+        title: feed.title,
+        imageUrl: feed.imageUrl,
+        description: feed.description,
+        lastFetchedAt: now,
+        createdAt: now,
+      })
+
+      for (const ep of feed.episodes) {
+        const exists = await episodeDao.findByGuid(subscription.id, ep.guid)
+        if (exists) continue
+        await episodeDao.insert({
+          id: crypto.randomUUID(),
+          subscriptionId: subscription.id,
+          guid: ep.guid,
+          title: ep.title,
+          description: ep.description,
+          duration: ep.duration,
+          publishedAt: ep.publishedAt,
+          mediaUrl: ep.mediaUrl,
+          fileSize: ep.fileSize,
+          createdAt: now,
+        })
+      }
+
+      return subscription
+    },
+
+    async unsubscribe(subscriptionId) {
+      await subscriptionDao.delete(subscriptionId)
+    },
+  }
+}

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,3 +1,4 @@
+import * as ExpoCrypto from 'expo-crypto'
 import { parseFeed } from '../rss/parser'
 import type { SubscriptionDao } from '../db/dao/subscriptionDao'
 import type { EpisodeDao } from '../db/dao/episodeDao'
@@ -17,7 +18,9 @@ export function createSubscriptionService(
       const existing = await subscriptionDao.findByFeedUrl(feedUrl)
       if (existing) throw new Error('Already subscribed to this feed')
 
-      const response = await fetch(feedUrl)
+      const response = await fetch(feedUrl, {
+        headers: { Accept: 'application/rss+xml, application/xml, text/xml, */*' },
+      })
       if (!response.ok) throw new Error(`Failed to fetch feed: HTTP ${response.status}`)
 
       const xml = await response.text()
@@ -25,7 +28,7 @@ export function createSubscriptionService(
 
       const now = Date.now()
       const subscription = await subscriptionDao.insert({
-        id: crypto.randomUUID(),
+        id: ExpoCrypto.randomUUID(),
         feedUrl: feed.feedUrl,
         title: feed.title,
         imageUrl: feed.imageUrl,
@@ -38,7 +41,7 @@ export function createSubscriptionService(
         const exists = await episodeDao.findByGuid(subscription.id, ep.guid)
         if (exists) continue
         await episodeDao.insert({
-          id: crypto.randomUUID(),
+          id: ExpoCrypto.randomUUID(),
           subscriptionId: subscription.id,
           guid: ep.guid,
           title: ep.title,


### PR DESCRIPTION
Closes #3

## Summary
Implements the full subscribe-via-RSS flow. Users can paste a feed URL, see it parsed and saved to the library, and remove it — all backed by the SQLite DAOs from #2.

## Stories completed
- RSS 2.0 + iTunes namespace parser (`src/rss/parser.ts`) — handles seconds and HH:MM:SS duration, defaults missing duration to 0, throws on malformed XML
- Subscription service (`src/services/subscriptionService.ts`) — fetches feed, parses, persists subscription + episodes; skips duplicate episodes by guid; throws descriptive errors without mutating the DB
- Library screen (`src/screens/LibraryScreen.tsx`) — URL input with loading state, subscription list, remove with confirmation dialog, error display
- `App.tsx` wired to SQLite database via `openDatabase()` and `LibraryScreen`
- `jest-setup.ts` adds `crypto.randomUUID` shim for the Jest environment

## Test plan
- [x] 7 RSS parser unit tests (valid feed, HH:MM:SS duration, missing duration, malformed XML, missing channel)
- [x] 8 subscription service unit tests (fetch, insert, episode dedup, duplicate feed, HTTP error, malformed XML, unsubscribe)
- [x] All 55 tests pass (`npm test`)
- [x] `tsc --noEmit` clean
- [ ] Verify on simulator: paste a real RSS URL, confirm podcast and episodes appear; remove and confirm deletion