### PR TITLE
Play an episode with full playback controls (closes #5)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,16 +1,33 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { View, ActivityIndicator, StyleSheet } from 'react-native'
 import { StatusBar } from 'expo-status-bar'
 import { openDatabase, type Database } from './src/db/database'
 import { createSubscriptionService } from './src/services/subscriptionService'
+import { createPlayerService, type PlayerService } from './src/services/playerService'
 import { LibraryScreen } from './src/screens/LibraryScreen'
+import { PlayerScreen } from './src/screens/PlayerScreen'
+import type { Episode, Subscription } from './src/db/types'
 
 export default function App() {
   const [db, setDb] = useState<Database | null>(null)
+  const [currentEpisode, setCurrentEpisode] = useState<Episode | null>(null)
+  const playerService = useRef<PlayerService>(createPlayerService())
 
   useEffect(() => {
-    openDatabase().then(setDb)
+    openDatabase().then((opened) => {
+      setDb(opened)
+      playerService.current.setup().catch(console.error)
+    })
   }, [])
+
+  async function handleSelectSubscription(sub: Subscription, episodeDao: Database['episodes']) {
+    const episodes = await episodeDao.findBySubscriptionId(sub.id)
+    if (!episodes.length) return
+    const episode = episodes[0]
+    setCurrentEpisode(episode)
+    await playerService.current.loadEpisode(episode)
+    await playerService.current.play()
+  }
 
   if (!db) {
     return (
@@ -24,13 +41,21 @@ export default function App() {
   const service = createSubscriptionService(db.subscriptions, db.episodes)
 
   return (
-    <>
-      <LibraryScreen subscriptionService={service} subscriptionDao={db.subscriptions} />
+    <View style={styles.root}>
+      <LibraryScreen
+        subscriptionService={service}
+        subscriptionDao={db.subscriptions}
+        onSelectSubscription={(sub) => handleSelectSubscription(sub, db.episodes)}
+      />
+      {currentEpisode ? (
+        <PlayerScreen episode={currentEpisode} playerService={playerService.current} />
+      ) : null}
       <StatusBar style="auto" />
-    </>
+    </View>
   )
 }
 
 const styles = StyleSheet.create({
+  root: { flex: 1 },
   loading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 })

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,9 +1,24 @@
 import App from '../App'
 
 jest.mock('../src/screens/LibraryScreen', () => ({ LibraryScreen: () => null }))
+jest.mock('../src/screens/PlayerScreen', () => ({ PlayerScreen: () => null }))
 jest.mock('../src/db/database', () => ({ openDatabase: jest.fn() }))
 jest.mock('../src/services/subscriptionService', () => ({
   createSubscriptionService: jest.fn(),
+}))
+jest.mock('../src/services/playerService', () => ({
+  createPlayerService: jest.fn().mockReturnValue({
+    setup: jest.fn().mockResolvedValue(undefined),
+    loadEpisode: jest.fn().mockResolvedValue(undefined),
+    play: jest.fn().mockResolvedValue(undefined),
+    pause: jest.fn().mockResolvedValue(undefined),
+    seekTo: jest.fn().mockResolvedValue(undefined),
+    setSpeed: jest.fn().mockResolvedValue(undefined),
+  }),
+}))
+jest.mock('react-native-track-player', () => ({
+  registerPlaybackService: jest.fn(),
+  default: { registerPlaybackService: jest.fn() },
 }))
 
 it('App exports a React component', () => {

--- a/__tests__/services/playerService.test.ts
+++ b/__tests__/services/playerService.test.ts
@@ -35,7 +35,9 @@ function makeEpisode(overrides: Partial<Episode> = {}): Episode {
 }
 
 describe('playerService', () => {
-  let TrackPlayer: ReturnType<typeof jest.mocked<typeof import('react-native-track-player').default>>
+  let TrackPlayer: ReturnType<
+    typeof jest.mocked<typeof import('react-native-track-player').default>
+  >
 
   beforeEach(() => {
     TrackPlayer = require('react-native-track-player')

--- a/__tests__/services/playerService.test.ts
+++ b/__tests__/services/playerService.test.ts
@@ -1,0 +1,87 @@
+import { createPlayerService } from '../../src/services/playerService'
+import type { Episode } from '../../src/db/types'
+
+jest.mock('react-native-track-player', () => ({
+  setupPlayer: jest.fn().mockResolvedValue(undefined),
+  updateOptions: jest.fn().mockResolvedValue(undefined),
+  reset: jest.fn().mockResolvedValue(undefined),
+  add: jest.fn().mockResolvedValue(undefined),
+  play: jest.fn().mockResolvedValue(undefined),
+  pause: jest.fn().mockResolvedValue(undefined),
+  seekTo: jest.fn().mockResolvedValue(undefined),
+  setRate: jest.fn().mockResolvedValue(undefined),
+  Capability: { Play: 'play', Pause: 'pause', SeekTo: 'seekTo' },
+  RepeatMode: { Off: 0 },
+}))
+
+function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+  return {
+    id: 'ep-1',
+    subscriptionId: 'sub-1',
+    guid: 'g1',
+    title: 'Test Episode',
+    description: null,
+    duration: 300,
+    publishedAt: null,
+    mediaUrl: 'https://example.com/ep1.mp3',
+    fileSize: null,
+    downloadStatus: 'none',
+    localPath: null,
+    playedAt: null,
+    isArchived: false,
+    createdAt: 1000,
+    ...overrides,
+  }
+}
+
+describe('playerService', () => {
+  let TrackPlayer: ReturnType<typeof jest.mocked<typeof import('react-native-track-player').default>>
+
+  beforeEach(() => {
+    TrackPlayer = require('react-native-track-player')
+    jest.clearAllMocks()
+  })
+
+  it('setup calls setupPlayer and updateOptions', async () => {
+    const service = createPlayerService()
+    await service.setup()
+    expect(TrackPlayer.setupPlayer).toHaveBeenCalledTimes(1)
+    expect(TrackPlayer.updateOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ capabilities: expect.any(Array) }),
+    )
+  })
+
+  it('loadEpisode calls reset then add with episode mediaUrl and title', async () => {
+    const service = createPlayerService()
+    const ep = makeEpisode()
+    await service.loadEpisode(ep)
+    expect(TrackPlayer.reset).toHaveBeenCalledTimes(1)
+    expect(TrackPlayer.add).toHaveBeenCalledWith(
+      expect.objectContaining({ url: ep.mediaUrl, title: ep.title }),
+    )
+  })
+
+  it('play calls TrackPlayer.play', async () => {
+    const service = createPlayerService()
+    await service.play()
+    expect(TrackPlayer.play).toHaveBeenCalledTimes(1)
+  })
+
+  it('pause calls TrackPlayer.pause', async () => {
+    const service = createPlayerService()
+    await service.pause()
+    expect(TrackPlayer.pause).toHaveBeenCalledTimes(1)
+  })
+
+  it('seekTo calls TrackPlayer.seekTo with the given position', async () => {
+    const service = createPlayerService()
+    await service.seekTo(120)
+    expect(TrackPlayer.seekTo).toHaveBeenCalledWith(120)
+  })
+
+  it('setSpeed calls TrackPlayer.setRate with the given rate', async () => {
+    const service = createPlayerService()
+    await service.setSpeed(1.5)
+    expect(TrackPlayer.setRate).toHaveBeenCalledWith(1.5)
+  })
+})

--- a/__tests__/tasks/playbackService.test.ts
+++ b/__tests__/tasks/playbackService.test.ts
@@ -1,0 +1,11 @@
+import { PlaybackService } from '../../src/tasks/playbackService'
+
+describe('PlaybackService', () => {
+  it('is a function', () => {
+    expect(typeof PlaybackService).toBe('function')
+  })
+
+  it('resolves without throwing', async () => {
+    await expect(PlaybackService()).resolves.toBeUndefined()
+  })
+})

--- a/app.json
+++ b/app.json
@@ -28,6 +28,6 @@
     "android": {
       "package": "dev.verylargenumbers.hlyst"
     },
-    "plugins": ["expo-sqlite", "react-native-track-player"]
+    "plugins": ["expo-sqlite"]
   }
 }

--- a/app.json
+++ b/app.json
@@ -28,6 +28,6 @@
     "android": {
       "package": "dev.verylargenumbers.hlyst"
     },
-    "plugins": ["expo-sqlite"]
+    "plugins": ["expo-sqlite", "react-native-track-player"]
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,8 @@
 import { registerRootComponent } from 'expo'
-
+import TrackPlayer from 'react-native-track-player'
+import { PlaybackService } from './src/tasks/playbackService'
 import App from './App'
+
+TrackPlayer.registerPlaybackService(() => PlaybackService)
 
 registerRootComponent(App)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "expo-status-bar": "~3.0.9",
         "fast-xml-parser": "^5.7.3",
         "react": "19.1.0",
-        "react-native": "0.81.5"
+        "react-native": "0.81.5",
+        "react-native-track-player": "^4.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.24.0",
@@ -12953,6 +12954,29 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-track-player": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-track-player/-/react-native-track-player-4.1.2.tgz",
+      "integrity": "sha512-cIgMlqVJx/95hirUWPRW8CHxiBFj9Rjl/voKHh2jF/2URYMTQyt76t/m2FKvjeYUW2doKv4QSCBIOUmtyDLtJw==",
+      "license": "Apache-2.0",
+      "funding": {
+        "url": "https://github.com/doublesymmetry/react-native-track-player?sponsor=1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6",
+        "react-native": ">=0.60.0-rc.2",
+        "react-native-windows": ">=0.63.0",
+        "shaka-player": "^4.7.9"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        },
+        "shaka-player": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "expo-status-bar": "~3.0.9",
     "fast-xml-parser": "^5.7.3",
     "react": "19.1.0",
-    "react-native": "0.81.5"
+    "react-native": "0.81.5",
+    "react-native-track-player": "^4.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",
@@ -46,7 +47,7 @@
       "./jest-setup.ts"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|react-native-track-player)"
     ]
   },
   "lint-staged": {

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -19,7 +19,11 @@ interface Props {
   onSelectSubscription?: (sub: Subscription) => void
 }
 
-export function LibraryScreen({ subscriptionService, subscriptionDao, onSelectSubscription }: Props) {
+export function LibraryScreen({
+  subscriptionService,
+  subscriptionDao,
+  onSelectSubscription,
+}: Props) {
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([])
   const [url, setUrl] = useState('')
   const [loading, setLoading] = useState(false)

--- a/src/screens/LibraryScreen.tsx
+++ b/src/screens/LibraryScreen.tsx
@@ -16,9 +16,10 @@ import type { SubscriptionDao } from '../db/dao/subscriptionDao'
 interface Props {
   subscriptionService: SubscriptionService
   subscriptionDao: SubscriptionDao
+  onSelectSubscription?: (sub: Subscription) => void
 }
 
-export function LibraryScreen({ subscriptionService, subscriptionDao }: Props) {
+export function LibraryScreen({ subscriptionService, subscriptionDao, onSelectSubscription }: Props) {
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([])
   const [url, setUrl] = useState('')
   const [loading, setLoading] = useState(false)
@@ -92,7 +93,11 @@ export function LibraryScreen({ subscriptionService, subscriptionDao }: Props) {
         data={subscriptions}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <View style={styles.row}>
+          <TouchableOpacity
+            style={styles.row}
+            onPress={() => onSelectSubscription?.(item)}
+            disabled={!onSelectSubscription}
+          >
             <View style={styles.rowText}>
               <Text style={styles.title}>{item.title}</Text>
               <Text style={styles.feedUrl} numberOfLines={1}>
@@ -102,7 +107,7 @@ export function LibraryScreen({ subscriptionService, subscriptionDao }: Props) {
             <TouchableOpacity onPress={() => handleDelete(item)}>
               <Text style={styles.remove}>Remove</Text>
             </TouchableOpacity>
-          </View>
+          </TouchableOpacity>
         )}
         ListEmptyComponent={<Text style={styles.empty}>No podcasts yet. Add one above.</Text>}
       />

--- a/src/screens/PlayerScreen.tsx
+++ b/src/screens/PlayerScreen.tsx
@@ -1,0 +1,112 @@
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { usePlaybackState, useProgress, State } from 'react-native-track-player'
+import type { Episode } from '../db/types'
+import type { PlayerService } from '../services/playerService'
+
+interface Props {
+  episode: Episode
+  playerService: PlayerService
+}
+
+const SPEEDS = [0.75, 1, 1.25, 1.5, 2] as const
+
+export function PlayerScreen({ episode, playerService }: Props) {
+  const playbackState = usePlaybackState()
+  const progress = useProgress()
+  const isPlaying = playbackState.state === State.Playing
+
+  const elapsed = Math.floor(progress.position)
+  const total = Math.floor(progress.duration || episode.duration || 0)
+
+  function fmt(s: number) {
+    const m = Math.floor(s / 60)
+    const sec = s % 60
+    return `${m}:${String(sec).padStart(2, '0')}`
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title} numberOfLines={2}>
+        {episode.title}
+      </Text>
+
+      <Text style={styles.time}>
+        {fmt(elapsed)} / {fmt(total)}
+      </Text>
+
+      <View style={styles.controls}>
+        <TouchableOpacity
+          style={styles.skipBtn}
+          onPress={() => playerService.seekTo(Math.max(0, progress.position - 15))}
+        >
+          <Text style={styles.skipText}>-15</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.playBtn}
+          onPress={() => (isPlaying ? playerService.pause() : playerService.play())}
+        >
+          <Text style={styles.playText}>{isPlaying ? '⏸' : '▶'}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.skipBtn}
+          onPress={() => playerService.seekTo(progress.position + 30)}
+        >
+          <Text style={styles.skipText}>+30</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.speeds}>
+        {SPEEDS.map((rate) => (
+          <TouchableOpacity
+            key={rate}
+            style={styles.speedBtn}
+            onPress={() => playerService.setSpeed(rate)}
+          >
+            <Text style={styles.speedText}>{rate}×</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f8f8f8',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#ddd',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  title: { fontSize: 15, fontWeight: '600', marginBottom: 6 },
+  time: { fontSize: 12, color: '#666', marginBottom: 12 },
+  controls: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 20 },
+  playBtn: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: '#007AFF',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  playText: { fontSize: 22, color: '#fff' },
+  skipBtn: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: '#e0e0e0',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  skipText: { fontSize: 13, fontWeight: '600', color: '#333' },
+  speeds: { flexDirection: 'row', justifyContent: 'center', gap: 8, marginTop: 12 },
+  speedBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+    backgroundColor: '#e8e8e8',
+  },
+  speedText: { fontSize: 13, color: '#333' },
+})

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -1,0 +1,48 @@
+import TrackPlayer, { Capability } from 'react-native-track-player'
+import type { Episode } from '../db/types'
+
+export interface PlayerService {
+  setup(): Promise<void>
+  loadEpisode(episode: Episode): Promise<void>
+  play(): Promise<void>
+  pause(): Promise<void>
+  seekTo(seconds: number): Promise<void>
+  setSpeed(rate: number): Promise<void>
+}
+
+export function createPlayerService(): PlayerService {
+  return {
+    async setup() {
+      await TrackPlayer.setupPlayer()
+      await TrackPlayer.updateOptions({
+        capabilities: [Capability.Play, Capability.Pause, Capability.SeekTo],
+      })
+    },
+
+    async loadEpisode(episode) {
+      await TrackPlayer.reset()
+      await TrackPlayer.add({
+        id: episode.id,
+        url: episode.mediaUrl,
+        title: episode.title,
+        artist: episode.subscriptionId,
+      })
+    },
+
+    async play() {
+      await TrackPlayer.play()
+    },
+
+    async pause() {
+      await TrackPlayer.pause()
+    },
+
+    async seekTo(seconds) {
+      await TrackPlayer.seekTo(seconds)
+    },
+
+    async setSpeed(rate) {
+      await TrackPlayer.setRate(rate)
+    },
+  }
+}

--- a/src/tasks/playbackService.ts
+++ b/src/tasks/playbackService.ts
@@ -1,0 +1,4 @@
+export async function PlaybackService() {
+  // RNTP calls this function when the headless task starts.
+  // Remote control events (lock screen, CarPlay) are handled by RNTP internally.
+}


### PR DESCRIPTION
## Summary
- Adds `PlayerService` wrapping react-native-track-player v4 (play, pause, seek, speed)
- Registers RNTP headless `PlaybackService` in `index.ts` before `registerRootComponent` — required for background playback and CarPlay
- Adds `PlayerScreen` with play/pause toggle, −15s/+30s skip buttons, and 0.75×/1×/1.25×/1.5×/2× speed selector
- Adds optional `onSelectSubscription` to `LibraryScreen` — tapping a subscription loads its most recent episode into the player
- Adds `react-native-track-player` Expo plugin to `app.json` (AVAudioSession `.playback` category, background audio)
- Updates Jest `transformIgnorePatterns` to allow RNTP to be transformed

## Test plan
- [x] `playerService` unit tests — 6 cases (setup, loadEpisode, play, pause, seekTo, setSpeed)
- [x] `playbackService` unit tests — function existence + resolves cleanly
- [x] `tsc --noEmit` passes
- [x] `npm test` passes (64 tests)
- [ ] **Native rebuild required after merge:** `expo run:ios` (react-native-track-player adds native modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)