### PR TITLE
Mini player redesign and tab bar navigation (closes #36, part of #18)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { View, ActivityIndicator, StyleSheet } from 'react-native'
+import { View, Text, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native'
 import { StatusBar } from 'expo-status-bar'
 import { openDatabase, type Database } from './src/db/database'
 import { createSubscriptionService } from './src/services/subscriptionService'
@@ -8,12 +8,20 @@ import { createFeedRefreshService } from './src/services/feedRefreshService'
 import { registerBackgroundFetch } from './src/tasks/backgroundRefreshTask'
 import { LibraryScreen } from './src/screens/LibraryScreen'
 import { PlayerScreen } from './src/screens/PlayerScreen'
+import { QueueScreen } from './src/screens/QueueScreen'
 import type { Episode, Subscription } from './src/db/types'
+
+type Tab = 'library' | 'queue'
 
 export default function App() {
   const [db, setDb] = useState<Database | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
   const [currentEpisode, setCurrentEpisode] = useState<Episode | null>(null)
+  const [currentSubscriptionImageUrl, setCurrentSubscriptionImageUrl] = useState<string | null>(
+    null,
+  )
+  const [currentPodcastName, setCurrentPodcastName] = useState('')
+  const [activeTab, setActiveTab] = useState<Tab>('library')
   const playerService = useRef<PlayerService>(createPlayerService())
 
   useEffect(() => {
@@ -42,6 +50,8 @@ export default function App() {
     if (!episodes.length) return
     const episode = episodes[0]
     setCurrentEpisode(episode)
+    setCurrentSubscriptionImageUrl(sub.imageUrl)
+    setCurrentPodcastName(sub.title)
     await playerService.current.loadEpisode(episode)
     await playerService.current.play()
   }
@@ -59,15 +69,40 @@ export default function App() {
 
   return (
     <View style={styles.root}>
-      <LibraryScreen
-        subscriptionService={service}
-        subscriptionDao={db.subscriptions}
-        refreshKey={refreshKey}
-        onSelectSubscription={(sub) => handleSelectSubscription(sub, db.episodes)}
-      />
+      <View style={styles.screenArea}>
+        {activeTab === 'library' ? (
+          <LibraryScreen
+            subscriptionService={service}
+            subscriptionDao={db.subscriptions}
+            refreshKey={refreshKey}
+            onSelectSubscription={(sub) => handleSelectSubscription(sub, db.episodes)}
+          />
+        ) : (
+          <QueueScreen />
+        )}
+      </View>
+
       {currentEpisode ? (
-        <PlayerScreen episode={currentEpisode} playerService={playerService.current} />
+        <PlayerScreen
+          episode={currentEpisode}
+          playerService={playerService.current}
+          imageUrl={currentSubscriptionImageUrl}
+          podcastName={currentPodcastName}
+          onQueuePress={() => setActiveTab('queue')}
+        />
       ) : null}
+
+      <View style={styles.tabBar}>
+        <TouchableOpacity style={styles.tab} onPress={() => setActiveTab('library')}>
+          <Text style={[styles.tabText, activeTab === 'library' && styles.tabTextActive]}>
+            Library
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.tab} onPress={() => setActiveTab('queue')}>
+          <Text style={[styles.tabText, activeTab === 'queue' && styles.tabTextActive]}>Queue</Text>
+        </TouchableOpacity>
+      </View>
+
       <StatusBar style="auto" />
     </View>
   )
@@ -76,4 +111,24 @@ export default function App() {
 const styles = StyleSheet.create({
   root: { flex: 1 },
   loading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  screenArea: { flex: 1 },
+  tabBar: {
+    flexDirection: 'row',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#ddd',
+    backgroundColor: '#fff',
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  tabText: {
+    fontSize: 15,
+    color: '#888',
+  },
+  tabTextActive: {
+    color: '#007AFF',
+    fontWeight: '700',
+  },
 })

--- a/App.tsx
+++ b/App.tsx
@@ -22,6 +22,7 @@ export default function App() {
   )
   const [currentPodcastName, setCurrentPodcastName] = useState('')
   const [activeTab, setActiveTab] = useState<Tab>('library')
+  const [showFullPlayer, setShowFullPlayer] = useState(false)
   const playerService = useRef<PlayerService>(createPlayerService())
 
   useEffect(() => {
@@ -52,8 +53,12 @@ export default function App() {
     setCurrentEpisode(episode)
     setCurrentSubscriptionImageUrl(sub.imageUrl)
     setCurrentPodcastName(sub.title)
-    await playerService.current.loadEpisode(episode)
-    await playerService.current.play()
+    try {
+      await playerService.current.loadEpisode(episode)
+      await playerService.current.play()
+    } catch (err) {
+      console.error('[App] failed to start playback:', err)
+    }
   }
 
   if (!db) {
@@ -89,6 +94,7 @@ export default function App() {
           imageUrl={currentSubscriptionImageUrl}
           podcastName={currentPodcastName}
           onQueuePress={() => setActiveTab('queue')}
+          onExpand={() => setShowFullPlayer(true)}
         />
       ) : null}
 

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -2,6 +2,7 @@ import App from '../App'
 
 jest.mock('../src/screens/LibraryScreen', () => ({ LibraryScreen: () => null }))
 jest.mock('../src/screens/PlayerScreen', () => ({ PlayerScreen: () => null }))
+jest.mock('../src/screens/QueueScreen', () => ({ QueueScreen: () => null }))
 jest.mock('../src/db/database', () => ({ openDatabase: jest.fn() }))
 jest.mock('../src/services/subscriptionService', () => ({
   createSubscriptionService: jest.fn(),

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,6 +1,33 @@
+import React, { createElement } from 'react'
+import { create, act } from 'react-test-renderer'
 import App from '../App'
+import { createPlayerService } from '../src/services/playerService'
+import { openDatabase } from '../src/db/database'
+import { createSubscriptionService } from '../src/services/subscriptionService'
 
-jest.mock('../src/screens/LibraryScreen', () => ({ LibraryScreen: () => null }))
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mockView = (props: Record<string, unknown>) =>
+    React.createElement('View', { testID: props.testID, style: props.style }, props.children)
+  const mockText = (props: Record<string, unknown>) =>
+    React.createElement('Text', { testID: props.testID }, props.children)
+  const mockTouchable = (props: Record<string, unknown>) =>
+    React.createElement(
+      'TouchableOpacity',
+      { testID: props.testID, onPress: props.onPress },
+      props.children,
+    )
+  const mockActivityIndicator = () => React.createElement('ActivityIndicator', {})
+  return {
+    View: mockView,
+    Text: mockText,
+    TouchableOpacity: mockTouchable,
+    ActivityIndicator: mockActivityIndicator,
+    StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 },
+  }
+})
+
+jest.mock('../src/screens/LibraryScreen', () => ({ LibraryScreen: jest.fn(() => null) }))
 jest.mock('../src/screens/PlayerScreen', () => ({ PlayerScreen: () => null }))
 jest.mock('../src/screens/QueueScreen', () => ({ QueueScreen: () => null }))
 jest.mock('../src/db/database', () => ({ openDatabase: jest.fn() }))
@@ -29,7 +56,77 @@ jest.mock('../src/services/feedRefreshService', () => ({
 jest.mock('../src/tasks/backgroundRefreshTask', () => ({
   registerBackgroundFetch: jest.fn().mockResolvedValue(undefined),
 }))
+jest.mock('expo-status-bar', () => ({ StatusBar: () => null }))
 
 it('App exports a React component', () => {
   expect(typeof App).toBe('function')
+})
+
+it('does not propagate when playerService.play rejects', async () => {
+  const mockEpisode = {
+    id: 'ep1',
+    subscriptionId: 'sub1',
+    guid: 'guid1',
+    title: 'Ep 1',
+    description: null,
+    duration: 100,
+    publishedAt: null,
+    mediaUrl: 'http://example.com/ep1.mp3',
+    fileSize: null,
+    downloadStatus: 'none',
+    localPath: null,
+    playedAt: null,
+    isArchived: false,
+    createdAt: Date.now(),
+  }
+  const mockSub = {
+    id: 'sub1',
+    title: 'Pod',
+    feedUrl: 'http://example.com/feed.xml',
+    imageUrl: null,
+  }
+
+  const mockEpisodesDao = { findBySubscriptionId: jest.fn().mockResolvedValue([mockEpisode]) }
+  const mockSubscriptionsDao = {}
+  const mockDb = { subscriptions: mockSubscriptionsDao, episodes: mockEpisodesDao }
+  ;(openDatabase as jest.Mock).mockResolvedValue(mockDb)
+  ;(createSubscriptionService as jest.Mock).mockReturnValue({})
+
+  const playerServiceInstance = {
+    setup: jest.fn().mockResolvedValue(undefined),
+    loadEpisode: jest.fn().mockResolvedValue(undefined),
+    play: jest.fn().mockRejectedValue(new Error('playback failed')),
+    pause: jest.fn().mockResolvedValue(undefined),
+    seekTo: jest.fn().mockResolvedValue(undefined),
+    setSpeed: jest.fn().mockResolvedValue(undefined),
+  }
+  ;(createPlayerService as jest.Mock).mockReturnValue(playerServiceInstance)
+
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  const { LibraryScreen } = jest.requireMock('../src/screens/LibraryScreen') as {
+    LibraryScreen: jest.Mock
+  }
+  let capturedOnSelectSubscription: ((sub: unknown) => void) | undefined
+  LibraryScreen.mockImplementation(
+    ({ onSelectSubscription }: { onSelectSubscription: (sub: unknown) => void }) => {
+      capturedOnSelectSubscription = onSelectSubscription
+      return null
+    },
+  )
+
+  await act(async () => {
+    create(createElement(App))
+  })
+
+  await act(async () => {
+    capturedOnSelectSubscription?.(mockSub)
+  })
+
+  await act(async () => {})
+
+  expect(consoleSpy).toHaveBeenCalledWith('[App] failed to start playback:', expect.any(Error))
+
+  consoleSpy.mockRestore()
+  LibraryScreen.mockReset()
 })

--- a/__tests__/screens/PlayerScreen.test.tsx
+++ b/__tests__/screens/PlayerScreen.test.tsx
@@ -1,0 +1,273 @@
+import React, { createElement } from 'react'
+import { create, act } from 'react-test-renderer'
+import type { Episode } from '../../src/db/types'
+import type { PlayerService } from '../../src/services/playerService'
+
+// Provide simple native-component mocks before importing the component
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mockView = (props: Record<string, unknown>) =>
+    React.createElement('View', { testID: props.testID, onPress: props.onPress }, props.children)
+  const mockText = (props: Record<string, unknown>) =>
+    React.createElement('Text', { testID: props.testID }, props.children)
+  const mockImage = (props: Record<string, unknown>) =>
+    React.createElement('Image', { testID: props.testID, source: props.source })
+  const mockTouchable = (props: Record<string, unknown>) =>
+    React.createElement(
+      'TouchableOpacity',
+      { testID: props.testID, onPress: props.onPress },
+      props.children,
+    )
+  return {
+    View: mockView,
+    Text: mockText,
+    Image: mockImage,
+    TouchableOpacity: mockTouchable,
+    StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 },
+  }
+})
+
+jest.mock('react-native-track-player', () => ({
+  usePlaybackState: jest.fn().mockReturnValue({ state: 'playing' }),
+  useProgress: jest.fn().mockReturnValue({ position: 30, duration: 3600 }),
+  State: { Playing: 'playing', Paused: 'paused' },
+  registerPlaybackService: jest.fn(),
+  default: { registerPlaybackService: jest.fn() },
+}))
+
+// Import after mocks are set up
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { PlayerScreen } =
+  require('../../src/screens/PlayerScreen') as typeof import('../../src/screens/PlayerScreen')
+
+const mockEpisode: Episode = {
+  id: 'ep-1',
+  subscriptionId: 'sub-1',
+  guid: 'guid-1',
+  title: 'Test Episode Title',
+  description: null,
+  duration: 3600,
+  publishedAt: null,
+  mediaUrl: 'https://example.com/ep.mp3',
+  fileSize: null,
+  downloadStatus: 'none',
+  localPath: null,
+  playedAt: null,
+  isArchived: false,
+  createdAt: Date.now(),
+}
+
+function makePlayerService(overrides: Partial<PlayerService> = {}): PlayerService {
+  return {
+    setup: jest.fn().mockResolvedValue(undefined),
+    loadEpisode: jest.fn().mockResolvedValue(undefined),
+    play: jest.fn().mockResolvedValue(undefined),
+    pause: jest.fn().mockResolvedValue(undefined),
+    seekTo: jest.fn().mockResolvedValue(undefined),
+    setSpeed: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+// Finds a node with a given testID in the rendered tree
+function findByTestId(instance: ReturnType<typeof create>, testId: string): unknown {
+  const search = (node: unknown): unknown => {
+    if (!node || typeof node !== 'object') return null
+    const n = node as { props?: Record<string, unknown>; children?: unknown[] }
+    if (n.props?.testID === testId) return n
+    if (n.children) {
+      for (const child of n.children) {
+        const found = search(child)
+        if (found) return found
+      }
+    }
+    return null
+  }
+  return search(instance.toJSON())
+}
+
+function pressNode(node: unknown) {
+  const n = node as { props?: { onPress?: () => void } }
+  n.props?.onPress?.()
+}
+
+describe('PlayerScreen', () => {
+  it('renders artwork placeholder when imageUrl is null', () => {
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: makePlayerService(),
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+        }),
+      )
+    })
+    expect(findByTestId(instance, 'artwork-placeholder')).toBeTruthy()
+  })
+
+  it('renders Image when imageUrl is provided', () => {
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: makePlayerService(),
+          imageUrl: 'https://example.com/art.png',
+          podcastName: 'Test Podcast',
+        }),
+      )
+    })
+    expect(findByTestId(instance, 'artwork-image')).toBeTruthy()
+  })
+
+  it('renders the episode title in the JSON output', () => {
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: makePlayerService(),
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+        }),
+      )
+    })
+    expect(JSON.stringify(instance.toJSON())).toContain('Test Episode Title')
+  })
+
+  it('renders the podcast name in the JSON output', () => {
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: makePlayerService(),
+          imageUrl: null,
+          podcastName: 'My Podcast',
+        }),
+      )
+    })
+    expect(JSON.stringify(instance.toJSON())).toContain('My Podcast')
+  })
+
+  it('renders the progress bar', () => {
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: makePlayerService(),
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+        }),
+      )
+    })
+    expect(findByTestId(instance, 'progress-bar')).toBeTruthy()
+  })
+
+  it('calls playerService.pause when play/pause pressed while playing', () => {
+    const service = makePlayerService()
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: service,
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+        }),
+      )
+    })
+    act(() => {
+      pressNode(findByTestId(instance, 'play-pause-btn'))
+    })
+    expect(service.pause).toHaveBeenCalled()
+  })
+
+  it('calls playerService.play when play/pause pressed while paused', () => {
+    const mockRntp = require('react-native-track-player') as {
+      usePlaybackState: jest.Mock
+    }
+    mockRntp.usePlaybackState.mockReturnValueOnce({ state: 'paused' })
+    const service = makePlayerService()
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: service,
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+        }),
+      )
+    })
+    act(() => {
+      pressNode(findByTestId(instance, 'play-pause-btn'))
+    })
+    expect(service.play).toHaveBeenCalled()
+  })
+
+  it('calls seekTo with position + 30 when +30 button pressed', () => {
+    const service = makePlayerService()
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: service,
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+        }),
+      )
+    })
+    act(() => {
+      pressNode(findByTestId(instance, 'skip-forward-btn'))
+    })
+    // progress.position is 30 from mock, so seekTo should be called with 60
+    expect(service.seekTo).toHaveBeenCalledWith(60)
+  })
+
+  it('calls onQueuePress when queue button is pressed', () => {
+    const service = makePlayerService()
+    const onQueuePress = jest.fn()
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: service,
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+          onQueuePress,
+        }),
+      )
+    })
+    act(() => {
+      pressNode(findByTestId(instance, 'queue-btn'))
+    })
+    expect(onQueuePress).toHaveBeenCalled()
+  })
+
+  it('calls onExpand when expand button is pressed', () => {
+    const service = makePlayerService()
+    const onExpand = jest.fn()
+    let instance!: ReturnType<typeof create>
+    act(() => {
+      instance = create(
+        createElement(PlayerScreen, {
+          episode: mockEpisode,
+          playerService: service,
+          imageUrl: null,
+          podcastName: 'Test Podcast',
+          onExpand,
+        }),
+      )
+    })
+    act(() => {
+      pressNode(findByTestId(instance, 'expand-btn'))
+    })
+    expect(onExpand).toHaveBeenCalled()
+  })
+})

--- a/__tests__/screens/QueueScreen.test.tsx
+++ b/__tests__/screens/QueueScreen.test.tsx
@@ -1,0 +1,47 @@
+import React, { createElement } from 'react'
+import { create, act } from 'react-test-renderer'
+
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mockView = (props: Record<string, unknown>) =>
+    React.createElement('View', { testID: props.testID }, props.children)
+  const mockText = (props: Record<string, unknown>) =>
+    React.createElement('Text', { testID: props.testID }, props.children)
+  return {
+    View: mockView,
+    Text: mockText,
+    StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 },
+  }
+})
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { QueueScreen } =
+  require('../../src/screens/QueueScreen') as typeof import('../../src/screens/QueueScreen')
+
+function findText(node: unknown, text: string): boolean {
+  if (!node || typeof node !== 'object') return false
+  const n = node as { children?: unknown[]; type?: string; props?: Record<string, unknown> }
+  if (n.children) {
+    for (const child of n.children) {
+      if (child === text) return true
+      if (findText(child, text)) return true
+    }
+  }
+  return false
+}
+
+it('renders the Queue heading', () => {
+  let instance!: ReturnType<typeof create>
+  act(() => {
+    instance = create(createElement(QueueScreen, null))
+  })
+  expect(findText(instance.toJSON(), 'Queue')).toBe(true)
+})
+
+it('renders the empty state text', () => {
+  let instance!: ReturnType<typeof create>
+  act(() => {
+    instance = create(createElement(QueueScreen, null))
+  })
+  expect(findText(instance.toJSON(), 'Nothing queued yet.')).toBe(true)
+})

--- a/src/screens/PlayerScreen.tsx
+++ b/src/screens/PlayerScreen.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { View, Text, Image, TouchableOpacity, StyleSheet } from 'react-native'
 import { usePlaybackState, useProgress, State } from 'react-native-track-player'
 import type { Episode } from '../db/types'
 import type { PlayerService } from '../services/playerService'
@@ -6,67 +6,78 @@ import type { PlayerService } from '../services/playerService'
 interface Props {
   episode: Episode
   playerService: PlayerService
+  imageUrl: string | null
+  podcastName: string
+  onQueuePress?: () => void
+  onExpand?: () => void
 }
 
-const SPEEDS = [0.75, 1, 1.25, 1.5, 2] as const
-
-export function PlayerScreen({ episode, playerService }: Props) {
+export function PlayerScreen({
+  episode,
+  playerService,
+  imageUrl,
+  podcastName,
+  onQueuePress,
+  onExpand,
+}: Props) {
   const playbackState = usePlaybackState()
   const progress = useProgress()
   const isPlaying = playbackState.state === State.Playing
 
-  const elapsed = Math.floor(progress.position)
-  const total = Math.floor(progress.duration || episode.duration || 0)
-
-  function fmt(s: number) {
-    const m = Math.floor(s / 60)
-    const sec = s % 60
-    return `${m}:${String(sec).padStart(2, '0')}`
-  }
+  const elapsed = progress.position
+  const total = progress.duration || episode.duration || 0
+  const progressFraction = total > 0 ? Math.min(elapsed / total, 1) : 0
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title} numberOfLines={2}>
-        {episode.title}
-      </Text>
-
-      <Text style={styles.time}>
-        {fmt(elapsed)} / {fmt(total)}
-      </Text>
-
-      <View style={styles.controls}>
+      <View style={styles.row}>
         <TouchableOpacity
-          style={styles.skipBtn}
-          onPress={() => playerService.seekTo(Math.max(0, progress.position - 15))}
+          testID="expand-btn"
+          style={styles.expandArea}
+          onPress={onExpand}
+          activeOpacity={0.7}
         >
-          <Text style={styles.skipText}>-15</Text>
+          {imageUrl ? (
+            <Image testID="artwork-image" source={{ uri: imageUrl }} style={styles.artwork} />
+          ) : (
+            <View testID="artwork-placeholder" style={styles.artworkPlaceholder} />
+          )}
+          <View style={styles.textArea}>
+            <Text style={styles.title} numberOfLines={1}>
+              {episode.title}
+            </Text>
+            <Text style={styles.subtitle} numberOfLines={1}>
+              {podcastName}
+            </Text>
+          </View>
         </TouchableOpacity>
 
-        <TouchableOpacity
-          style={styles.playBtn}
-          onPress={() => (isPlaying ? playerService.pause() : playerService.play())}
-        >
-          <Text style={styles.playText}>{isPlaying ? '⏸' : '▶'}</Text>
-        </TouchableOpacity>
+        <View style={styles.controls}>
+          <TouchableOpacity testID="queue-btn" style={styles.iconBtn} onPress={onQueuePress}>
+            <Text style={styles.iconText}>≡</Text>
+          </TouchableOpacity>
 
-        <TouchableOpacity
-          style={styles.skipBtn}
-          onPress={() => playerService.seekTo(progress.position + 30)}
-        >
-          <Text style={styles.skipText}>+30</Text>
-        </TouchableOpacity>
+          <TouchableOpacity
+            testID="play-pause-btn"
+            style={styles.iconBtn}
+            onPress={() => (isPlaying ? playerService.pause() : playerService.play())}
+          >
+            <Text style={styles.iconText}>{isPlaying ? '⏸' : '▶'}</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            testID="skip-forward-btn"
+            style={styles.iconBtn}
+            onPress={() => playerService.seekTo(progress.position + 30)}
+          >
+            <Text style={styles.iconText}>⏩</Text>
+          </TouchableOpacity>
+        </View>
       </View>
 
-      <View style={styles.speeds}>
-        {SPEEDS.map((rate) => (
-          <TouchableOpacity
-            key={rate}
-            style={styles.speedBtn}
-            onPress={() => playerService.setSpeed(rate)}
-          >
-            <Text style={styles.speedText}>{rate}×</Text>
-          </TouchableOpacity>
-        ))}
+      <View testID="progress-bar" style={styles.progressTrack}>
+        <View style={[styles.progressFill, { flex: progressFraction }]} />
+        <View style={{ flex: 1 - progressFraction }} />
       </View>
     </View>
   )
@@ -77,36 +88,56 @@ const styles = StyleSheet.create({
     backgroundColor: '#f8f8f8',
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: '#ddd',
-    paddingHorizontal: 16,
-    paddingVertical: 14,
   },
-  title: { fontSize: 15, fontWeight: '600', marginBottom: 6 },
-  time: { fontSize: 12, color: '#666', marginBottom: 12 },
-  controls: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 20 },
-  playBtn: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: '#007AFF',
-    justifyContent: 'center',
+  row: {
+    flexDirection: 'row',
     alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
   },
-  playText: { fontSize: 22, color: '#fff' },
-  skipBtn: {
+  expandArea: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    minWidth: 0,
+  },
+  artwork: {
     width: 48,
     height: 48,
-    borderRadius: 24,
-    backgroundColor: '#e0e0e0',
+    borderRadius: 4,
+    backgroundColor: '#ccc',
+  },
+  artworkPlaceholder: {
+    width: 48,
+    height: 48,
+    borderRadius: 4,
+    backgroundColor: '#ccc',
+  },
+  textArea: {
+    flex: 1,
+    minWidth: 0,
+  },
+  title: { fontSize: 14, fontWeight: '600', color: '#111' },
+  subtitle: { fontSize: 12, color: '#888', marginTop: 2 },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  iconBtn: {
+    width: 36,
+    height: 36,
     justifyContent: 'center',
     alignItems: 'center',
   },
-  skipText: { fontSize: 13, fontWeight: '600', color: '#333' },
-  speeds: { flexDirection: 'row', justifyContent: 'center', gap: 8, marginTop: 12 },
-  speedBtn: {
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 6,
-    backgroundColor: '#e8e8e8',
+  iconText: { fontSize: 18 },
+  progressTrack: {
+    height: 2,
+    flexDirection: 'row',
+    backgroundColor: '#e0e0e0',
   },
-  speedText: { fontSize: 13, color: '#333' },
+  progressFill: {
+    backgroundColor: '#007AFF',
+  },
 })

--- a/src/screens/QueueScreen.tsx
+++ b/src/screens/QueueScreen.tsx
@@ -1,0 +1,16 @@
+import { View, Text, StyleSheet } from 'react-native'
+
+export function QueueScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Queue</Text>
+      <Text style={styles.empty}>Nothing queued yet.</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingTop: 60, paddingHorizontal: 16, backgroundColor: '#fff' },
+  heading: { fontSize: 28, fontWeight: '700', marginBottom: 20 },
+  empty: { textAlign: 'center', color: '#888', marginTop: 48 },
+})


### PR DESCRIPTION
## Summary

- Redesigns `PlayerScreen` as a compact mini player bar with album artwork, episode title, podcast name, and three icon buttons (≡ queue, ⏸/▶ play-pause, ⏩ +30s skip), plus a thin non-interactive progress bar below
- Adds `QueueScreen` placeholder (`src/screens/QueueScreen.tsx`) with empty state text
- Adds state-based tab bar (Library / Queue) to `App.tsx`; mini player sits between the screen area and the tab bar
- ≡ queue button on the mini player switches to the Queue tab via `onQueuePress` prop
- New props on `PlayerScreen`: `imageUrl: string | null`, `podcastName: string`, `onQueuePress?: () => void`, `onExpand?: () => void`
- No new npm packages or navigation libraries introduced

## Test plan

- [x] `__tests__/screens/PlayerScreen.test.tsx` — 10 tests: artwork placeholder, artwork image render, episode title, podcast name, progress bar, play/pause (playing state), play/pause (paused state), +30s seek, queue button, expand button
- [x] `__tests__/screens/QueueScreen.test.tsx` — 2 tests: Queue heading, empty state text
- [x] All 100 tests pass (`npx jest --no-coverage`)
- [x] No TypeScript errors (`npx tsc --noEmit`)
- [x] Prettier formatted (`npx prettier --write .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)